### PR TITLE
Initial raketasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -148,6 +148,13 @@ task :update_sunsets do
   puts "ending"
 end
 
+task :update_conditions do
+  puts "starting"
+  require APP_ROOT.join('app', 'helpers', 'weather.rb')
+  Weather.get_conditions
+  puts "ending"
+end
+
 task :text_users do
   require APP_ROOT.join('app', 'helpers', 'text_users.rb')
   texting

--- a/Rakefile
+++ b/Rakefile
@@ -137,6 +137,16 @@ desc "Run the specs"
 
 task :default  => :spec
 
+##### Initial Setup ############
+desc "Run this task on initial deployment"
+
+task :initial_setup do
+  puts "Starting setup"
+  system("rake update_sunsets")
+  system("rake update_conditions")
+  puts "Ending setup"
+end
+
 ##### Scheduled Tasks ##########
 
 desc "These tasks is called by the Heroku scheduler add-on"


### PR DESCRIPTION
These tasks will allow us to populate the table on initial deployment.  Without this information the page will not render.  This is because the index page relies on having sunsets and conditions available from the table.
